### PR TITLE
remove the provenance file from the dataset

### DIFF
--- a/src/main/java/life/qbic/registration/openbis/OpenBisDropboxETL.java
+++ b/src/main/java/life/qbic/registration/openbis/OpenBisDropboxETL.java
@@ -77,26 +77,16 @@ public class OpenBisDropboxETL extends AbstractJavaDataSetRegistrationDropboxV2 
 
   private void moveFiles(IDataSetRegistrationTransactionV2 transactionV2, IDataSet dataSet, File provenanceFile) {
 
-    byte[] buffer = null;
     try {
-      buffer = Files.readAllBytes(provenanceFile.toPath().toAbsolutePath());
+      var buffer = Files.readAllBytes(provenanceFile.toPath().toAbsolutePath());
       Files.delete(provenanceFile.toPath());
-      transactionV2.moveFile(transactionV2.getIncoming().getAbsolutePath(), dataSet);
-    } catch (RuntimeException e) {
-      //recover provenance file
       try {
+        transactionV2.moveFile(transactionV2.getIncoming().getAbsolutePath(), dataSet);
+      } catch (Exception e) {
         Files.write(provenanceFile.toPath().toAbsolutePath(), buffer);
-      } catch (IOException ex) {
-        throw new RuntimeException(ex);
+        throw new RuntimeException(e);
       }
-      throw e;
     } catch (IOException e) {
-      //recover provenance file
-      try {
-        Files.write(provenanceFile.toPath().toAbsolutePath(), buffer);
-      } catch (IOException ex) {
-        throw new RuntimeException(ex);
-      }
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/life/qbic/registration/openbis/OpenBisDropboxETL.java
+++ b/src/main/java/life/qbic/registration/openbis/OpenBisDropboxETL.java
@@ -71,24 +71,14 @@ public class OpenBisDropboxETL extends AbstractJavaDataSetRegistrationDropboxV2 
     newDataSet.setPropertyValue(QPropertyType.Q_TASK_ID.getOpenBisPropertyName(), dataSetProvenance.taskId());
     QDatasetType qDatasetType = getDatasetType(measurementSample);
     newDataSet.setDataSetType(qDatasetType.name());
-    moveFiles(transaction, newDataSet, provenanceFile);
-
-  }
-
-  private void moveFiles(IDataSetRegistrationTransactionV2 transactionV2, IDataSet dataSet, File provenanceFile) {
 
     try {
-      var buffer = Files.readAllBytes(provenanceFile.toPath().toAbsolutePath());
       Files.delete(provenanceFile.toPath());
-      try {
-        transactionV2.moveFile(transactionV2.getIncoming().getAbsolutePath(), dataSet);
-      } catch (Exception e) {
-        Files.write(provenanceFile.toPath().toAbsolutePath(), buffer);
-        throw new RuntimeException(e);
-      }
+        transaction.moveFile(transaction.getIncoming().getAbsolutePath(), newDataSet);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+
   }
 
   private static QDatasetType getDatasetType(ISampleImmutable measurementSample) {


### PR DESCRIPTION
removes the provenance files, moves the folder into the dataset and writes the file again if something went wrong.

See #3 for details on the reason for this change.